### PR TITLE
Added DeepSeek Support

### DIFF
--- a/caribou/src/caribou/cli/config_cli.py
+++ b/caribou/src/caribou/cli/config_cli.py
@@ -2,6 +2,7 @@
 import re
 import typer
 from rich.console import Console
+from typing import Optional
 
 # Import the centralized ENV_FILE path
 from caribou.config import ENV_FILE
@@ -39,3 +40,35 @@ def set_api_key(
 
     ENV_FILE.write_text(new_content.strip())
     console.print(f"[bold green]✅ OpenAI API key has been set successfully in:[/bold green] {ENV_FILE}")
+
+@config_app.command("set-deepseek-key")
+def set_deepseek_key(
+    ctx: typer.Context,
+    api_key: Optional[str] = typer.Argument(None, help="Your DeepSeek API key (e.g., 'ds_...')"),
+):
+    """
+    Saves your DeepSeek API key to the Caribou environment file.
+    """
+    if api_key is None:
+        console.print("[bold red]Error:[/bold red] You must provide an API key.\n")
+        typer.echo(ctx.parent.get_help())
+        raise typer.Exit()
+
+    if not api_key.startswith("ds_"):
+        console.print(
+            "[yellow]Warning: Key does not look like a standard DeepSeek API key (should start with 'ds_').[/yellow]"
+        )
+
+    if not ENV_FILE.exists():
+        ENV_FILE.touch()
+
+    content = ENV_FILE.read_text()
+    key_to_set = f'DEEPSEEK_API_KEY="{api_key}"'
+
+    if re.search(r"^DEEPSEEK_API_KEY=.*$", content, flags=re.MULTILINE):
+        new_content = re.sub(r"^DEEPSEEK_API_KEY=.*$", key_to_set, content, flags=re.MULTILINE)
+    else:
+        new_content = content.strip() + f"\n{key_to_set}\n"
+
+    ENV_FILE.write_text(new_content)
+    console.print(f"[bold green]✅ DeepSeek API key has been set successfully in:[/bold green] {ENV_FILE}")

--- a/caribou/src/caribou/cli/run_cli.py
+++ b/caribou/src/caribou/cli/run_cli.py
@@ -12,6 +12,7 @@ import typer
 from rich.console import Console
 from rich.prompt import Prompt, IntPrompt
 from dotenv import load_dotenv
+
 from caribou.config import DEFAULT_AGENT_DIR, ENV_FILE, CARIBOU_HOME
 
 
@@ -70,6 +71,7 @@ class AppContext:
         self.analysis_context: str | None = None
         self.sandbox_manager: 'SandboxManager' | None = None
         self.llm_client: object | None = None
+        self.model_name: str | None = None # <-- ADDED
         self.initial_history: List[dict] | None = None
         self.dataset_path: Path | None = None
         self.reference_dataset_path: Optional[Path] = None
@@ -84,12 +86,11 @@ def main_run_callback(
     dataset: Path = typer.Option(None, "--dataset", "-ds", help="Path to the primary dataset file (.h5ad).", readable=True),
     reference_dataset: Path = typer.Option(None, "--reference-dataset", "-ref", help="Path to an optional reference dataset file (.h5ad).", readable=True),
     resources_dir: Path = typer.Option(None, "--resources", help="Path to a directory of resource files to mount.", exists=True, file_okay=False),
-    llm_backend: str = typer.Option(None, "--llm", help="LLM backend to use: 'chatgpt' or 'ollama'."),
+    llm_backend: str = typer.Option(None, "--llm", help="LLM backend to use: 'chatgpt', 'ollama', or 'deepseek'."),
     ollama_host: str = typer.Option("http://localhost:11434", "--ollama-host", help="Base URL for Ollama backend."),
     sandbox: str = typer.Option(None, "--sandbox", help="Sandbox backend to use: 'docker' or 'singularity'."),
     force_refresh: bool = typer.Option(False, "--force-refresh", help="Force refresh/rebuild of the sandbox environment."),
 ):
-    # --- Heavy imports are deferred to here ---
     from caribou.agents.AgentSystem import AgentSystem
     from caribou.core.io_helpers import collect_resources, prompt_for_file
     from caribou.core.sandbox_management import init_docker, init_singularity_exec
@@ -132,22 +133,41 @@ def main_run_callback(
     elif sandbox == "singularity":
         manager_class, handle, copy_cmd, exec_endpoint, status_endpoint = init_singularity_exec(script_dir, SANDBOX_DATA_PATH, subprocess, console, force_refresh=force_refresh)
     else:
-        raise typer.BadParameter(f"Unknown sandbox type '{sandbox}'. Supported: 'docker', 'singularity'.")
+        raise typer.BadParameter(f"Unknown sandbox type '{sandbox}'.")
     app_context.sandbox_manager = manager_class()
     app_context.sandbox_details = {"handle": handle, "copy_cmd": copy_cmd, "is_exec_mode": sandbox == "singularity"}
 
+    # --- MODIFIED: LLM Backend Selection ---
     if llm_backend is None:
-        llm_backend = Prompt.ask("Choose an LLM backend", choices=["chatgpt", "ollama"], default="chatgpt")
-    if llm_backend == "ollama" and ollama_host == "http://localhost:11434":
-         ollama_host = Prompt.ask("Enter the Ollama base URL", default="http://localhost:11434")
-
+        llm_backend = Prompt.ask("Choose an LLM backend", choices=["chatgpt", "ollama", "deepseek"], default="chatgpt")
+    
     console.print(f"[cyan]Initializing LLM backend: {llm_backend}[/cyan]")
+
     if llm_backend == "chatgpt":
         from openai import OpenAI
+        if not os.getenv("OPENAI_API_KEY"):
+            console.print("[bold red]Error: OPENAI_API_KEY not set. Use 'caribou config set-openai-key'.[/bold red]")
+            raise typer.Exit(1)
         app_context.llm_client = OpenAI(api_key=os.getenv("OPENAI_API_KEY"))
+        app_context.model_name = "gpt-4o"
+    
+    elif llm_backend == "deepseek":
+        from openai import OpenAI
+        if not os.getenv("DEEPSEEK_API_KEY"):
+            console.print("[bold red]Error: DEEPSEEK_API_KEY not set. Use 'caribou config set-deepseek-key'.[/bold red]")
+            raise typer.Exit(1)
+        app_context.llm_client = OpenAI(
+            api_key=os.getenv("DEEPSEEK_API_KEY"),
+            base_url="https://api.deepseek.com"
+        )
+        app_context.model_name = "deepseek-chat"
+
     elif llm_backend == "ollama":
-        from caribou.core.ollama_wrapper import OllamaClient as OpenAI
-        app_context.llm_client = OpenAI(host=ollama_host)
+        if ollama_host == "http://localhost:11434":
+             ollama_host = Prompt.ask("Enter the Ollama base URL", default="http://localhost:11434")
+        from caribou.core.ollama_wrapper import OllamaClient
+        app_context.llm_client = OllamaClient(host=ollama_host)
+        app_context.model_name = "llama3"
     else:
         raise typer.BadParameter(f"Unknown LLM backend '{llm_backend}'.")
 
@@ -163,6 +183,7 @@ def main_run_callback(
     driver = app_context.agent_system.get_agent(driver_agent)
     system_prompt = (app_context.roster_instructions + "\n\n" + driver.get_full_prompt(app_context.agent_system.global_policy) + "\n\n" + app_context.analysis_context)
     app_context.initial_history = [{"role": "system", "content": system_prompt}]
+
 
 def _setup_and_run_session(context: AppContext, history: list, is_auto: bool, max_turns: int, benchmark_modules: Optional[List[Path]] = None):
     """Helper to start, run, and stop the sandbox session."""
@@ -201,7 +222,8 @@ def _setup_and_run_session(context: AppContext, history: list, is_auto: bool, ma
             history=history,
             is_auto=is_auto,
             max_turns=max_turns,
-            benchmark_modules=benchmark_modules
+            benchmark_modules=benchmark_modules,
+            model_name=cast(str, context.model_name) # <-- ADDED
         )
     finally:
         console.print("[cyan]Stopping sandbox...[/cyan]")
@@ -226,6 +248,7 @@ def _setup_and_run_session(context: AppContext, history: list, is_auto: bool, ma
                     save_chat_history_as_notebook(console, history, save_path)
                 else:
                     save_chat_history_as_json(console, history, save_path)
+
 
 @run_app.command("interactive")
 def run_interactive(ctx: typer.Context):
@@ -278,4 +301,4 @@ def run_auto(
         is_auto=True,
         max_turns=turns,
         benchmark_modules=[benchmark_module] if benchmark_module else None
-)
+    )

--- a/caribou/src/caribou/execution/runner.py
+++ b/caribou/src/caribou/execution/runner.py
@@ -158,6 +158,7 @@ def run_agent_session(
     history: List[Dict[str, str]],
     is_auto: bool,
     max_turns: int = 1,
+    model_name: str = "gpt-4.1",
     benchmark_modules: Optional[List[Path]] = None,
 ):
     """
@@ -187,7 +188,7 @@ def run_agent_session(
         
         try:
             resp = llm_client.chat.completions.create(
-                model="gpt-4.1",
+                model=model_name,
                 messages=history,
                 temperature=0.7,
             )


### PR DESCRIPTION
This pull request adds support for the DeepSeek LLM backend to Caribou, allowing users to select DeepSeek as an option when running agent sessions. It introduces a new CLI command for configuring the DeepSeek API key, updates the LLM backend selection logic to handle DeepSeek, and ensures the model name is passed through to agent sessions for all backends.

**DeepSeek LLM Integration**

* Added a new CLI command `set-deepseek-key` in `config_cli.py` to save the DeepSeek API key to the environment file. The command validates the key format and updates the config file accordingly.
* Updated the LLM backend selection in `run_cli.py` to support DeepSeek as an option, including error handling for missing API keys and setting the appropriate model name and endpoint for DeepSeek.
* Modified the prompt for LLM backend selection to include "deepseek" as a choice.

**Model Name Propagation**

* Added a `model_name` attribute to the application context and ensured it is passed to the agent session runner, allowing the correct model to be used for each backend. [[1]](diffhunk://#diff-38b3b29dea0e32cb1cc3f2118d70d126903c65ca8697257b3cbe590908e646e2R74) [[2]](diffhunk://#diff-38b3b29dea0e32cb1cc3f2118d70d126903c65ca8697257b3cbe590908e646e2L204-R226) [[3]](diffhunk://#diff-c8037cad14ca482fca183dc63c6327135fd1e1254cc6a80640d2dd9c3be54804R161) [[4]](diffhunk://#diff-c8037cad14ca482fca183dc63c6327135fd1e1254cc6a80640d2dd9c3be54804L190-R191)

**General CLI Improvements**

* Improved error messages and help prompts for missing API keys for both OpenAI and DeepSeek backends.
* Cleaned up imports and minor formatting in CLI files. [[1]](diffhunk://#diff-a5212fcd4757b01c3ab61e5b0ce40c033e648295f7be71b86dda88ab0a0151a9R5) [[2]](diffhunk://#diff-38b3b29dea0e32cb1cc3f2118d70d126903c65ca8697257b3cbe590908e646e2R15)

These changes collectively make it easier for users to configure and use DeepSeek as an LLM backend, while ensuring robust handling of model selection and configuration.