### PR TITLE
Agent Delegation Patch

### DIFF
--- a/caribou/src/caribou/agents/olaf_fully_connected.json
+++ b/caribou/src/caribou/agents/olaf_fully_connected.json
@@ -86,10 +86,6 @@
         "enabled": true
       },
       "neighbors": {
-        "delegate_to_input": {
-          "target_agent": "input_agent",
-          "description": "input_agent will load and inspect the data"
-        },
         "delegate_to_QC_metrics": {
           "target_agent": "QC_metrics_agent",
           "description": "QC_metrics_agent will calculate QC metrics and provide QC information through informative plots"
@@ -139,10 +135,6 @@
           "target_agent": "input_agent",
           "description": "input_agent will load and inspect the data"
         },
-        "delegate_to_QC_metrics": {
-          "target_agent": "QC_metrics_agent",
-          "description": "QC_metrics_agent will calculate QC metrics and provide QC information through informative plots"
-        },
         "delegate_to_doublets": {
           "target_agent": "doublet_agent",
           "description": "doublet_agent will calculate doublets using Scrublet and removing them as well"
@@ -190,10 +182,6 @@
           "target_agent": "QC_metrics_agent",
           "description": "QC_metrics_agent will calculate QC metrics and provide QC information through informative plots"
         },
-        "delegate_to_doublets": {
-          "target_agent": "doublet_agent",
-          "description": "doublet_agent will calculate doublets using Scrublet and removing them as well"
-        },
         "delegate_to_downstream": {
           "target_agent": "downstream_agent",
           "description": "downstream agent will run standard scanpy processing steps"
@@ -240,10 +228,6 @@
         "delegate_to_doublets": {
           "target_agent": "doublet_agent",
           "description": "doublet_agent will calculate doublets using Scrublet and removing them as well"
-        },
-        "delegate_to_downstream": {
-          "target_agent": "downstream_agent",
-          "description": "downstream agent will run standard scanpy processing steps"
         },
         "delegate_to_QCEmbedding": {
           "target_agent": "QCEmbedding_agent",
@@ -293,10 +277,6 @@
           "target_agent": "downstream_agent",
           "description": "downstream agent will run standard scanpy processing steps"
         },
-        "delegate_to_QCEmbedding": {
-          "target_agent": "QCEmbedding_agent",
-          "description": "QCEmbedding_agent will show QC metrics on embeddings"
-        },
         "delegate_to_MAD": {
           "target_agent": "MAD_agent",
           "description": "MAD_agent will calculate median absolute deviation for QC metrics and filter cells accordingly"
@@ -344,10 +324,6 @@
           "target_agent": "QCEmbedding_agent",
           "description": "QCEmbedding_agent will show QC metrics on embeddings"
         },
-        "delegate_to_MAD": {
-          "target_agent": "MAD_agent",
-          "description": "MAD_agent will calculate median absolute deviation for QC metrics and filter cells accordingly"
-        },
         "delegate_to_Reprocess": {
           "target_agent": "Reprocess_agent",
           "description": "Reprocess_agent will re-analyze the data after QC has been applied"
@@ -394,10 +370,6 @@
         "delegate_to_MAD": {
           "target_agent": "MAD_agent",
           "description": "MAD_agent will calculate median absolute deviation for QC metrics and filter cells accordingly"
-        },
-        "delegate_to_Reprocess": {
-          "target_agent": "Reprocess_agent",
-          "description": "Reprocess_agent will re-analyze the data after QC has been applied"
         },
         "delegate_to_Celltyping": {
           "target_agent": "Celltyping_agent",
@@ -447,10 +419,6 @@
           "target_agent": "Reprocess_agent",
           "description": "Reprocess_agent will re-analyze the data after QC has been applied"
         },
-        "delegate_to_Celltyping": {
-          "target_agent": "Celltyping_agent",
-          "description": "Celltyping_agent will use CellTypist or provided markers to annotate data"
-        },
         "delegate_to_Integration": {
           "target_agent": "Integration_agent",
           "description": "Integration_agent will use scVI or Harmony to integrate data"
@@ -498,10 +466,6 @@
         "delegate_to_Celltyping": {
           "target_agent": "Celltyping_agent",
           "description": "Celltyping_agent will use CellTypist or provided markers to annotate data"
-        },
-        "delegate_to_Integration": {
-          "target_agent": "Integration_agent",
-          "description": "Integration_agent will use scVI or Harmony to integrate data"
         }
       },
       "code_samples": [

--- a/caribou/src/caribou/execution/runner.py
+++ b/caribou/src/caribou/execution/runner.py
@@ -235,8 +235,8 @@ def run_agent_session(
             new_agent = agent_system.get_agent(target_agent_name)
             if new_agent:
                 routing_message = f"🔄 Routing to '{target_agent_name}' via {cmd}"
-                system_prompt = (current_agent.get_full_prompt(agent_system.global_policy) + "\n\n" + analysis_context)
                 current_agent = new_agent
+                system_prompt = (current_agent.get_full_prompt(agent_system.global_policy) + "\n\n" + analysis_context)
                 console.print(f"[yellow]{routing_message}[/yellow]")
                 history.append({"role": "assistant", "content": f"🔄 Routing to **{target_agent_name}** (command `{cmd}`)"})
                 if memory_manager:


### PR DESCRIPTION
This pull request primarily removes several agent delegation links from the `neighbors` section of the `olaf_fully_connected.json` agent configuration, effectively reducing the set of agents that `olaf_fully_connected` can delegate tasks to. Additionally, there is a minor adjustment in the agent routing logic within the runner script to ensure the system prompt is set after updating the current agent.

### Agent configuration updates (`olaf_fully_connected.json`):

**Delegation removals:**
* Removed delegation to `input_agent`, `QC_metrics_agent`, `doublet_agent`, `downstream_agent`, `QCEmbedding_agent`, `MAD_agent`, `Reprocess_agent`, `Celltyping_agent`, and `Integration_agent`, meaning `olaf_fully_connected` will no longer route tasks to these agents. [[1]](diffhunk://#diff-4180d5f8f85c27df044c5a123fe57e135af56370af3a1d3b0a323b75daf4a819L89-L92) [[2]](diffhunk://#diff-4180d5f8f85c27df044c5a123fe57e135af56370af3a1d3b0a323b75daf4a819L142-L145) [[3]](diffhunk://#diff-4180d5f8f85c27df044c5a123fe57e135af56370af3a1d3b0a323b75daf4a819L193-L196) [[4]](diffhunk://#diff-4180d5f8f85c27df044c5a123fe57e135af56370af3a1d3b0a323b75daf4a819L244-L247) [[5]](diffhunk://#diff-4180d5f8f85c27df044c5a123fe57e135af56370af3a1d3b0a323b75daf4a819L296-L299) [[6]](diffhunk://#diff-4180d5f8f85c27df044c5a123fe57e135af56370af3a1d3b0a323b75daf4a819L347-L350) [[7]](diffhunk://#diff-4180d5f8f85c27df044c5a123fe57e135af56370af3a1d3b0a323b75daf4a819L398-L401) [[8]](diffhunk://#diff-4180d5f8f85c27df044c5a123fe57e135af56370af3a1d3b0a323b75daf4a819L450-L453) [[9]](diffhunk://#diff-4180d5f8f85c27df044c5a123fe57e135af56370af3a1d3b0a323b75daf4a819L501-L504)

### Runner logic adjustment (`runner.py`):

**Prompt initialization fix:**
* Moved the initialization of `system_prompt` to occur after updating `current_agent`, ensuring that the prompt reflects the correct agent context when routing.