### PR TITLE
Implemented auto benchmarks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,6 @@ bin/
 benchmarking/datasets/*.h5ad
 dev/
 */dist/
+*.log
+benchmarking/auto_runs/*
+!benchmarking/auto_runs/auto_run_template.sh

--- a/benchmarking/auto_runs/auto_run_template.sh
+++ b/benchmarking/auto_runs/auto_run_template.sh
@@ -1,0 +1,48 @@
+#!/bin/bash
+#SBATCH --job-name=auto_run  # More descriptive job name
+#SBATCH --cpus-per-task=8             # Number of CPU cores
+#SBATCH --mem=16GB                    # Total RAM requested
+#SBATCH --time=24:00:00               # Max wall time (hh:mm:ss)
+#SBATCH --output=auto_run.log  # Updated log file name
+#SBATCH --partition=cpu
+
+BLUEPRINT_PATH="full blue print path"
+DATASET_PATH="full dataset path"
+SANDBOX_BACKEND="singularity"
+LLM_BACKEND="deepseek"
+NUM_TURNS=15
+OUTPUT_DIR="full output dir path"
+DESCRIPTION="logs_F_mem_deep"
+BENCHMARK_PATH="full benchmark module path"
+JOB_ID=${SLURM_JOB_ID:-$$}
+for i in {1..10}
+do
+  echo "--- Starting Run $i ---"
+
+  INITIAL_PROMPT="Prompt goes here"
+  RUN_DIR="$OUTPUT_DIR/${DESCRIPTION}_${JOB_ID}_$i"
+  # save params in run directory
+  mkdir -p "$RUN_DIR"
+  echo "BLUEPRINT_PATH: $BLUEPRINT_PATH" > "$RUN_DIR/params.txt"
+  echo "DATASET_PATH: $DATASET_PATH" >> "$RUN_DIR/params.txt"
+  echo "SANDBOX_BACKEND: $SANDBOX_BACKEND" >> "$RUN_DIR/params.txt"
+  echo "LLM_BACKEND: $LLM_BACKEND" >> "$RUN_DIR/params.txt"
+  echo "NUM_TURNS: $NUM_TURNS" >> "$RUN_DIR/params.txt"
+  echo "INITIAL_PROMPT: $INITIAL_PROMPT" >> "$RUN_DIR/params.txt"
+
+  caribou run auto \
+    --blueprint "$BLUEPRINT_PATH" \
+    --dataset "$DATASET_PATH" \
+    --sandbox "$SANDBOX_BACKEND" \
+    --llm "$LLM_BACKEND" \
+    --turns "$NUM_TURNS" \
+    --prompt "$INITIAL_PROMPT" \
+    --driver-agent "master_agent" \
+    --output-dir "$RUN_DIR" \
+    --benchmark-module "$BENCHMARK_PATH"
+
+  echo "--- Run $i Finished ---"
+  echo "" 
+done
+
+echo "--- All Runs Complete ---"

--- a/caribou/src/caribou/cli/run_cli.py
+++ b/caribou/src/caribou/cli/run_cli.py
@@ -6,6 +6,7 @@ import textwrap
 from pathlib import Path
 from typing import List, Tuple, Optional, cast, Dict, Any
 import subprocess
+import json
 from datetime import datetime
 
 import typer
@@ -59,7 +60,7 @@ class AppContext:
         self.resources: List[Tuple[Path, str]] = []
         self.sandbox_details: dict = {}
         self.compress_memory: bool = False
-        # holds any callback-provided options to merge in subcommands
+        self.output_dir: Optional[Path] = None
         self.parent_params: Dict[str, Any] = {}
 
 # --------------------------------------------------------------------------------------
@@ -127,6 +128,7 @@ def _setup_and_run_session(
 ) -> None:
     """
     Start, run, and stop the sandbox session with proper resource handling and logging.
+    Manages output saving based on whether context.output_dir is set.
     """
     from caribou.execution.runner import run_agent_session, SandboxManager
     from caribou.agents.AgentSystem import AgentSystem
@@ -136,20 +138,23 @@ def _setup_and_run_session(
     sandbox_manager = cast(SandboxManager, context.sandbox_manager)
     console = context.console
     
-    # 1. Create a unique, temporary output directory on the host machine.
-    output_dir = CARIBOU_HOME / "runs" / "session_outputs"
     timestamp = datetime.now().strftime("%Y%m%d-%H%M%S")
-    host_output_path = output_dir / f"run_{timestamp}"
-    host_output_path.mkdir(parents=True, exist_ok=True)
-    
-    console.print(f"Session outputs will be staged in: [cyan]{host_output_path}[/cyan]")
-    
+    if context.output_dir:
+        host_output_path = context.output_dir
+        host_output_path.mkdir(parents=True, exist_ok=True) # Ensure it exists
+        console.print(f"Session outputs will be saved to specified directory: [cyan]{host_output_path}[/cyan]")
+    else:
+        # Default behavior: create a timestamped temporary directory
+        temp_output_dir = CARIBOU_HOME / "runs" / "session_outputs"
+        host_output_path = temp_output_dir / f"run_{timestamp}"
+        host_output_path.mkdir(parents=True, exist_ok=True)
+        console.print(f"Session outputs will be staged in temporary directory: [cyan]{host_output_path}[/cyan]")
+
     console.print("[cyan]Starting sandbox...[/cyan]")
     
     details = context.sandbox_details
     dataset_path = cast(Path, context.dataset_path)
 
-    # 2. For Singularity, configure the shared output folder before starting.
     if details.get("is_exec_mode") and hasattr(sandbox_manager, "set_data"):
         all_resources = [(dataset_path, SANDBOX_DATA_PATH)] + list(context.resources)
         sandbox_manager.set_data(all_resources, host_output_path)
@@ -159,7 +164,6 @@ def _setup_and_run_session(
         raise typer.Exit(1)
     
     try:
-        # For Docker, copy files into the running container.
         if not details.get("is_exec_mode"):
             copy_cmd = details["copy_cmd"]
             handle = details["handle"]
@@ -167,7 +171,6 @@ def _setup_and_run_session(
             for host_path, container_path in context.resources:
                 copy_cmd(str(host_path), f"{handle}:{container_path}")
 
-        # 3. Run the main agent session.
         run_agent_session(
             console=console,
             agent_system=cast(AgentSystem, context.agent_system),
@@ -181,70 +184,73 @@ def _setup_and_run_session(
             benchmark_modules=benchmark_modules,
             model_name=cast(str, context.model_name),
             compress_memory=context.compress_memory,
+            output_dir=host_output_path if context.output_dir else None,
         )
     finally:
-        # 4. Handle file retrieval and cleanup BEFORE stopping the container.
-        if not is_auto:
-            if details.get("is_exec_mode"):
-                # --- Singularity Workflow ---
-                console.print("\n[bold]Review generated files:[/bold]")
-                output_files = list(host_output_path.iterdir())
-                if output_files:
-                    for f in output_files:
-                        size_mb = f.stat().st_size / 1e6
-                        console.print(f"  - {f.name} ([yellow]{size_mb:.2f} MB[/yellow])")
-                    
-                    if Prompt.ask(f"\nDo you want to keep the output directory and its contents?", choices=["y", "n"], default="y").lower() == 'n':
-                        shutil.rmtree(host_output_path)
-                        console.print(f"[dim]Removed temporary output directory.[/dim]")
-                    else:
+        auto_save_mode = context.output_dir is not None
+
+        if hasattr(sandbox_manager, "list_output_files"):
+            output_files_info = sandbox_manager.list_output_files() if not details.get("is_exec_mode") else \
+                                [{"name": f.name, "size": f"{f.stat().st_size / 1e6:.2f} MB"} for f in host_output_path.iterdir() if f.is_file()]
+
+            if output_files_info:
+                if auto_save_mode:
+                    if details.get("is_exec_mode"):
                         console.print(f"[bold green]✓ Session outputs saved in:[/bold green] {host_output_path}")
-                else:
-                    console.print("[dim]No output files were generated.[/dim]")
-                    # Clean up the empty staging directory
-                    shutil.rmtree(host_output_path)
-            else:
-                # --- Docker Workflow ---
-                if hasattr(sandbox_manager, "list_output_files"):
-                    output_files = sandbox_manager.list_output_files()
-                    if output_files:
-                        console.print("\n[bold]The following files were generated in the sandbox:[/bold]")
+                    else: # Docker: retrieve files automatically
+                        files_to_copy = [f["name"] for f in output_files_info]
+                        sandbox_manager.retrieve_output_files(host_output_path, files_to_copy)
+                else: # Interactive prompting mode
+                    console.print("\n[bold]Review generated files:[/bold]")
+                    if details.get("is_exec_mode"): # Singularity
+                        if Prompt.ask(f"\nDo you want to keep the output directory and its contents?", choices=["y", "n"], default="y").lower() == 'n':
+                            shutil.rmtree(host_output_path)
+                            console.print(f"[dim]Removed temporary output directory.[/dim]")
+                        else:
+                            console.print(f"[bold green]✓ Session outputs saved in:[/bold green] {host_output_path}")
+                    else: # Docker
                         from rich.table import Table
                         table = Table(title="Generated Output Files")
-                        table.add_column("Index", style="cyan")
-                        table.add_column("Filename")
-                        table.add_column("Size", style="yellow")
-                        for i, f in enumerate(output_files, 1):
-                            table.add_row(str(i), f["name"], f["size"])
+                        table.add_column("Index", style="cyan"); table.add_column("Filename"); table.add_column("Size", style="yellow")
+                        for i, f in enumerate(output_files_info, 1): table.add_row(str(i), f["name"], f["size"])
                         console.print(table)
-                        
                         if Prompt.ask("\n[bold]Do you want to save any of these files?[/bold]", choices=["y", "n"], default="y").lower() == 'y':
-                            files_to_copy = [f["name"] for f in output_files]
+                            files_to_copy = [f["name"] for f in output_files_info]
                             sandbox_manager.retrieve_output_files(host_output_path, files_to_copy)
                         else:
                             console.print("Generated files will be discarded.")
-                    else:
-                        console.print("\n[dim]No output files were generated in the sandbox.[/dim]")
+                            shutil.rmtree(host_output_path) # Clean up staging dir if Docker outputs aren't saved
+            else:
+                 console.print("\n[dim]No output files were generated.[/dim]")
+                 # Clean up the empty staging directory if nothing was produced
+                 if host_output_path.exists(): shutil.rmtree(host_output_path)
 
         console.print("[cyan]Stopping sandbox...[/cyan]")
         sandbox_manager.stop_container()
 
-        # 5. Handle chat history saving AFTER the container is stopped.
-        if not is_auto:
-            if Prompt.ask("\n[bold]Do you want to save the chat history?[/bold]", choices=["y", "n"], default="y").lower() == "y":
-                log_dir = CARIBOU_HOME / "runs" / "chat_logs"
-                timestamp = datetime.now().strftime("%Y%m%d-%H%M%S")
-                save_format = Prompt.ask("Save format", choices=["json", "notebook"], default="notebook")
+        save_chat = auto_save_mode or \
+                    (not is_auto and Prompt.ask("\n[bold]Do you want to save the chat history?[/bold]", choices=["y", "n"], default="y").lower() == "y")
+
+        if save_chat:
+            log_dir = host_output_path if auto_save_mode else (CARIBOU_HOME / "runs" / "chat_logs")
+            log_dir.mkdir(parents=True, exist_ok=True) # Ensure log dir exists, especially if output_dir was used
+
+            if auto_save_mode:
+                # Default to notebook format when using --output-dir
+                save_format = "notebook"
+                file_extension = ".ipynb"
+                save_path = log_dir / f"chat_log_{timestamp}{file_extension}"
+            else: # Interactive prompt for format and location
+                save_format = Prompt.ask("Save chat log format", choices=["json", "notebook"], default="notebook")
                 file_extension = ".ipynb" if save_format == "notebook" else ".json"
-                
                 default_path = log_dir / f"interactive_chat_{timestamp}{file_extension}"
-                save_path_str = Prompt.ask("Enter the save path for the log", default=str(default_path))
+                save_path_str = Prompt.ask("Enter the save path for the chat log", default=str(default_path))
                 save_path = Path(save_path_str).expanduser()
 
-                if save_format == "notebook":
-                    save_chat_history_as_notebook(console, history, save_path)
-                else:
-                    save_chat_history_as_json(console, history, save_path)
+            if save_format == "notebook":
+                save_chat_history_as_notebook(console, history, save_path)
+            else:
+                save_chat_history_as_json(console, history, save_path)
 
 # --------------------------------------------------------------------------------------
 # Initialization (shared for callback and subcommands)
@@ -263,6 +269,7 @@ def initialize_context(
     sandbox: Optional[str],
     force_refresh: bool,
     compress_memory: bool,
+    output_dir: Optional[Path], # <-- ADDED
 ) -> None:
     """
     Build out the AppContext with all shared resources and configuration.
@@ -272,12 +279,13 @@ def initialize_context(
     from caribou.core.io_helpers import collect_resources, prompt_for_file
     from caribou.core.sandbox_management import init_docker, init_singularity_exec
     from caribou.datasets.czi_datasets import get_datasets_dir
-    from openai import OpenAI  # Used for both OpenAI and DeepSeek-compatible clients
+    from openai import OpenAI
 
     load_dotenv(dotenv_path=ENV_FILE)
 
     console = context.console
     context.compress_memory = compress_memory
+    context.output_dir = output_dir # <-- Store output dir
 
     # ---- Agent System Blueprint ----
     if blueprint is None:
@@ -296,7 +304,7 @@ def initialize_context(
         dataset = prompt_for_file(console, get_datasets_dir(), PACKAGE_DATASETS_DIR, ".h5ad", "Primary Dataset")
     context.dataset_path = dataset
 
-    if reference_dataset is None:
+    if reference_dataset is None and output_dir is None: # Only prompt if not in auto-save mode
         if Prompt.ask("Do you want to add a reference dataset?", choices=["y", "n"], default="n").lower() == "y":
             reference_dataset = prompt_for_file(console, get_datasets_dir(), PACKAGE_DATASETS_DIR, ".h5ad", "Reference Dataset")
     context.reference_dataset_path = reference_dataset
@@ -349,9 +357,8 @@ def initialize_context(
             raise typer.Exit(1)
         context.llm_client = OpenAI(api_key=os.getenv("DEEPSEEK_API_KEY"), base_url="https://api.deepseek.com")
         context.model_name = "deepseek-chat"
-
     elif llm_backend == "ollama":
-        if ollama_host == "http://localhost:11434":
+        if ollama_host == "http://localhost:11434" and output_dir is None:
             ollama_host = Prompt.ask("Enter the Ollama base URL", default="http://localhost:11434")
         from caribou.core.ollama_wrapper import OllamaClient
         context.llm_client = OllamaClient(host=ollama_host)
@@ -368,13 +375,10 @@ def initialize_context(
     analysis_context_str = f"Primary dataset path: **{SANDBOX_DATA_PATH}**\n"
     if context.reference_dataset_path:
         analysis_context_str += f"Reference dataset path: **{SANDBOX_REF_DATA_PATH}**\n"
-    
-    # Add the crucial instruction for the agent
     analysis_context_str += "\n**IMPORTANT**: Please save all generated output files (plots, .h5ad, .csv) to the `/workspace/outputs/` directory."
-    
     context.analysis_context = textwrap.dedent(analysis_context_str)
     
-    driver = context.agent_system.get_agent(driver_agent)
+    driver = context.agent_system.get_agent(context.driver_agent_name)
     system_prompt = (driver.get_full_prompt(context.agent_system.global_policy) + "\n\n" + context.analysis_context)
     context.initial_history = [
         {"role": "system", "content": f"**GLOBAL POLICY**: {context.agent_system.global_policy}\n"},
@@ -382,69 +386,65 @@ def initialize_context(
     ]
 
 # --------------------------------------------------------------------------------------
-# Helpers to merge options from callback (parent) and subcommand
+# Helpers to merge options
 # --------------------------------------------------------------------------------------
 
 def _merge(parent: Dict[str, Any], **child: Any) -> Dict[str, Any]:
-    """Merge subcommand options with callback options; child takes precedence if not None."""
+    """Merge options, child takes precedence if not None."""
     merged = dict(parent)
     for k, v in child.items():
         if v is not None:
-            merged[k] = v
+            if isinstance(v, bool) and not v: 
+                if k not in parent or parent[k] is False:
+                    merged[k] = v
+            else:
+                 merged[k] = v
     return merged
 
 def _extract_common_kwargs(params: Dict[str, Any]) -> Dict[str, Any]:
-    """Pick only the shared options from a params dict for initialize_context."""
+    """Pick only the shared options for initialize_context."""
     keys = [
         "blueprint", "driver_agent", "dataset", "reference_dataset",
         "resources_dir", "llm_backend", "ollama_host", "sandbox",
-        "force_refresh", "compress_memory",
+        "force_refresh", "compress_memory", "output_dir", # <-- ADDED
     ]
-    out: Dict[str, Any] = {}
-    for k in keys:
-        out[k] = params.get(k, None)
-    # booleans default to False if absent
+    out = {k: params.get(k, None) for k in keys}
     out["force_refresh"] = bool(out.get("force_refresh", False))
     out["compress_memory"] = bool(out.get("compress_memory", False))
-    # default ollama_host if missing
-    if out.get("ollama_host") is None:
-        out["ollama_host"] = "http://localhost:11434"
+    if out.get("ollama_host") is None: out["ollama_host"] = "http://localhost:11434"
     return out
 
 # --------------------------------------------------------------------------------------
-# Callback: capture flags (for caribou run --flag) and default behavior if no subcommand
+# Callback
 # --------------------------------------------------------------------------------------
 
 @run_app.callback(invoke_without_command=True)
 def main_run_callback(
     ctx: typer.Context,
-    blueprint: Path = typer.Option(None, "--blueprint", "-bp", help="Path to the agent system JSON blueprint.", readable=True),
-    driver_agent: str = typer.Option(None, "--driver-agent", "-d", help="Name of the agent to start with."),
-    dataset: Path = typer.Option(None, "--dataset", "-ds", help="Path to the primary dataset file (.h5ad).", readable=True),
-    reference_dataset: Path = typer.Option(None, "--reference-dataset", "-ref", help="Path to an optional reference dataset file (.h5ad).", readable=True),
-    resources_dir: Path = typer.Option(None, "--resources", help="Path to a directory of resource files to mount.", exists=True, file_okay=False),
-    llm_backend: str = typer.Option(None, "--llm", help="LLM backend to use: 'chatgpt', 'ollama', or 'deepseek'."),
+    blueprint: Optional[Path] = typer.Option(None, "--blueprint", "-bp", help="Path to the agent system JSON blueprint.", readable=True),
+    driver_agent: Optional[str] = typer.Option(None, "--driver-agent", "-d", help="Name of the agent to start with."),
+    dataset: Optional[Path] = typer.Option(None, "--dataset", "-ds", help="Path to the primary dataset file (.h5ad).", readable=True),
+    reference_dataset: Optional[Path] = typer.Option(None, "--reference-dataset", "-ref", help="Path to an optional reference dataset file (.h5ad).", readable=True),
+    resources_dir: Optional[Path] = typer.Option(None, "--resources", help="Path to a directory of resource files to mount.", exists=True, file_okay=False),
+    llm_backend: Optional[str] = typer.Option(None, "--llm", help="LLM backend: 'chatgpt', 'ollama', or 'deepseek'."),
     ollama_host: str = typer.Option("http://localhost:11434", "--ollama-host", help="Base URL for Ollama backend."),
-    sandbox: str = typer.Option(None, "--sandbox", help="Sandbox backend to use: 'docker' or 'singularity'."),
+    sandbox: Optional[str] = typer.Option(None, "--sandbox", help="Sandbox backend: 'docker' or 'singularity'."),
     force_refresh: bool = typer.Option(False, "--force-refresh", help="Force refresh/rebuild of the sandbox environment."),
     compress_memory: bool = typer.Option(False, "--compress-memory", help="Enable episodic summarization to manage long-term context."),
+    output_dir: Optional[Path] = typer.Option(None, "--output-dir", "-o", help="Directory to save ALL outputs (files and logs) non-interactively.", file_okay=False, writable=True, resolve_path=True),
 ) -> None:
     """
-    Captures top-level flags for `caribou run --flag` and stores them.
-    If no subcommand is invoked, default to interactive (so `caribou run --flag` works).
+    Captures top-level flags and defaults to interactive mode if no subcommand.
     """
     app_context = getattr(ctx, "obj", None)
     if app_context is None:
         app_context = AppContext()
         ctx.obj = app_context
 
-    # Save parent (callback) params so subcommands can merge them with their own flags.
     parent_params = _extract_common_kwargs(locals())
-    # remove ctx itself from locals-based capture
     parent_params.pop("ctx", None)
     app_context.parent_params = parent_params
 
-    # If a subcommand is specified, DO NOT run anything here.
     if ctx.invoked_subcommand is not None:
         return
 
@@ -456,12 +456,9 @@ def main_run_callback(
 
     console = app_context.console
     console.print("\n[bold blue]🚀 Starting Interactive Mode...[/bold blue]")
-
     benchmark_module = _prompt_for_benchmark_module(console)
-
     history = list(app_context.initial_history or [])
     history.append({"role": "user", "content": "Beginning interactive session. What is the plan?"})
-
     _setup_and_run_session(
         context=app_context,
         history=history,
@@ -471,7 +468,7 @@ def main_run_callback(
     )
 
 # --------------------------------------------------------------------------------------
-# Subcommands (also accept flags so `caribou run interactive --flag` works)
+# Subcommands
 # --------------------------------------------------------------------------------------
 
 @run_app.command("interactive")
@@ -488,6 +485,7 @@ def run_interactive(
     sandbox: str = typer.Option(None, "--sandbox", help="Sandbox backend to use: 'docker' or 'singularity'."),
     force_refresh: bool = typer.Option(False, "--force-refresh", help="Force refresh/rebuild of the sandbox environment."),
     compress_memory: bool = typer.Option(False, "--compress-memory", help="Enable episodic summarization to manage long-term context."),
+    output_dir: Optional[Path] = typer.Option(None, "--output-dir", "-o", help="Directory to save ALL outputs (files and logs) non-interactively.", file_okay=False, writable=True, resolve_path=True),
 ) -> None:
     """
     Run the agent system in a manual, interactive chat session.
@@ -505,12 +503,9 @@ def run_interactive(
 
     console = context.console
     console.print("\n[bold blue]🚀 Starting Interactive Mode...[/bold blue]")
-
     benchmark_module = _prompt_for_benchmark_module(console)
-
     history = list(context.initial_history or [])
     history.append({"role": "user", "content": "Beginning interactive session. What is the plan?"})
-
     _setup_and_run_session(
         context=context,
         history=history,
@@ -533,7 +528,7 @@ def run_auto(
     sandbox: str = typer.Option(None, "--sandbox", help="Sandbox backend to use: 'docker' or 'singularity'."),
     force_refresh: bool = typer.Option(False, "--force-refresh", help="Force refresh/rebuild of the sandbox environment."),
     compress_memory: bool = typer.Option(False, "--compress-memory", help="Enable episodic summarization to manage long-term context."),
-    # auto-specific options
+    output_dir: Optional[Path] = typer.Option(None, "--output-dir", "-o", help="Directory to save ALL outputs (files and logs) non-interactively.", file_okay=False, writable=True, resolve_path=True),
     prompt: Optional[str] = typer.Option(None, "--prompt", "-p", help="Initial prompt for the auto run."),
     turns: Optional[int] = typer.Option(None, "--turns", "-t", help="Number of turns to run automatically."),
     benchmark_module: Optional[Path] = typer.Option(None, "--benchmark-module", "-bm", help="Path to the auto metric script.", readable=True, exists=True),
@@ -553,20 +548,26 @@ def run_auto(
     initialize_context(context, **merged)
 
     console = context.console
-
-    if prompt is None:
-        prompt = Prompt.ask("Enter the initial prompt for the automated run", default="Analyze this dataset.")
-
-    if turns is None:
-        turns = IntPrompt.ask("Enter the number of turns for the automated run", default=3)
-
-    if benchmark_module is None:
-        benchmark_module = _prompt_for_benchmark_module(console)
+    
+    if context.output_dir is None:
+        if prompt is None:
+            prompt = Prompt.ask("Enter the initial prompt", default="Analyze this dataset.")
+        if turns is None:
+            turns = IntPrompt.ask("Enter the number of turns", default=3)
+        if benchmark_module is None:
+            benchmark_module = _prompt_for_benchmark_module(console)
+    else: # If output_dir IS set, require prompt and turns via flags
+        if prompt is None:
+            console.print("[bold red]Error: --prompt is required when using --output-dir for automated runs.[/bold red]")
+            raise typer.Exit(1)
+        if turns is None:
+            turns = 3 # Default turns if not specified in pure auto mode
+            console.print(f"[yellow]--turns not specified, defaulting to {turns}.[/yellow]")
 
     console.print(f"\n[bold green]🚀 Starting Automated Mode for {turns} turns...[/bold green]")
 
     history = list(context.initial_history or [])
-    history.append({"role": "user", "content": prompt})
+    history.append({"role": "user", "content": str(prompt)})
 
     _setup_and_run_session(
         context=context,

--- a/caribou/src/caribou/execution/runner.py
+++ b/caribou/src/caribou/execution/runner.py
@@ -37,19 +37,31 @@ class SandboxManager:
 
 # --- Constants and Path Setup ---
 _DELEG_RE = re.compile(r"delegate_to_([A-Za-z0-9_]+)")
-_OUTPUTS_DIR = CARIBOU_HOME / "runs"
-_SNIPPET_DIR = _OUTPUTS_DIR / "snippets"
-_LEDGER_PATH = _OUTPUTS_DIR / f"benchmark_history_{datetime.utcnow().strftime('%Y%m%d-%H%M%S')}.jsonl"
 _RAG_RE = re.compile(r"query_rag_<([^>]+)>")
-RAG = RetrievalAugmentedGeneration()
 
+# Default output directories if --output-dir is NOT specified
+_DEFAULT_RUNS_DIR = CARIBOU_HOME / "runs"
+_DEFAULT_SNIPPET_DIR = _DEFAULT_RUNS_DIR / "snippets"
+_DEFAULT_BENCHMARK_LEDGER_PATH = _DEFAULT_RUNS_DIR / f"benchmark_history_{datetime.utcnow().strftime('%Y%m%d-%H%M%S')}.jsonl"
 
-def _init_paths():
+# --- Lazily initialize RAG ---
+_RAG_SINGLETON = None
+def get_rag_client(console: Console) -> RetrievalAugmentedGeneration:
+    global _RAG_SINGLETON
+    if _RAG_SINGLETON is None:
+        console.print("[cyan]Initializing RAG model (this may take a moment)...[/cyan]")
+        _RAG_SINGLETON = RetrievalAugmentedGeneration()
+    return _RAG_SINGLETON
+
+def _init_paths(output_dir: Optional[Path] = None):
     """Ensure output directories exist before writing."""
-    _SNIPPET_DIR.mkdir(exist_ok=True, parents=True)
-    _LEDGER_PATH.parent.mkdir(exist_ok=True, parents=True)
+    snippet_dir = output_dir / "snippets" if output_dir else _DEFAULT_SNIPPET_DIR
+    ledger_path = output_dir / "benchmark_results.jsonl" if output_dir else _DEFAULT_BENCHMARK_LEDGER_PATH
+    
+    snippet_dir.mkdir(exist_ok=True, parents=True)
+    ledger_path.parent.mkdir(exist_ok=True, parents=True)
 
-# --- Helper Functions (from original script) ---
+# --- Helper Functions ---
 def detect_delegation(msg: str) -> Optional[str]:
     """Return the *full* command name (e.g. 'delegate_to_coder') if present."""
     m = _DELEG_RE.search(msg)
@@ -58,16 +70,21 @@ def detect_delegation(msg: str) -> Optional[str]:
 def detect_rag(msg: str) -> Optional[str]:
     """Return the *partial* RAG command if present."""
     m = _RAG_RE.search(msg)
-    return f"{m.group(1)}" if m else None
+    return m.group(1) if m else None
 
-def _dump_code_snippet(run_id: str, code: str) -> str:
-    """Write <run_id>.py under outputs/snippets/ and return the relative path."""
-    snippet_path = _SNIPPET_DIR / f"{run_id}.py"
+def _dump_code_snippet(run_id: str, code: str, output_dir: Optional[Path] = None) -> str:
+    """Write <run_id>.py under the appropriate snippets dir and return the relative path."""
+    base_output_dir = output_dir if output_dir else _DEFAULT_RUNS_DIR
+    snippet_dir = base_output_dir / "snippets"
+    snippet_dir.mkdir(exist_ok=True, parents=True) # Ensure it exists
+    
+    snippet_path = snippet_dir / f"{run_id}.py"
     snippet_path.write_text(code, encoding="utf-8")
-    return str(snippet_path.relative_to(_OUTPUTS_DIR))
+    # Return path relative to the main output directory for consistency in the log
+    return str(snippet_path.relative_to(base_output_dir))
 
-def _save_benchmark_record(*, run_id: str, results: dict, meta: dict, code: str | None):
-    """Append a JSONL record for the benchmark run."""
+def _save_benchmark_record(*, run_id: str, results: dict, meta: dict, code: str | None, output_dir: Optional[Path] = None):
+    """Append a JSONL record for the benchmark run to the correct ledger file."""
     record = {
         "ts": datetime.utcnow().isoformat(timespec="seconds") + "Z",
         "run": run_id,
@@ -75,11 +92,14 @@ def _save_benchmark_record(*, run_id: str, results: dict, meta: dict, code: str 
         "results": results,
     }
     if code:
-        record["code_path"] = _dump_code_snippet(run_id, code)
-    with _LEDGER_PATH.open("a") as fh:
+        record["code_path"] = _dump_code_snippet(run_id, code, output_dir)
+        
+    # Determine the correct ledger path
+    ledger_path = output_dir / "benchmark_results.jsonl" if output_dir else _DEFAULT_BENCHMARK_LEDGER_PATH
+    
+    with ledger_path.open("a") as fh:
         fh.write(json.dumps(record) + "\n")
     
-        
 # --- Core Runner Functions ---
 def run_benchmark(
     console: Console,
@@ -87,6 +107,7 @@ def run_benchmark(
     benchmark_module: Path,
     *,
     is_auto: bool,
+    output_dir: Optional[Path] = None,
     metadata: Optional[Dict] = None,
     agent_name: Optional[str] = None,
     code_snippet: Optional[str] = None,
@@ -133,6 +154,7 @@ def run_benchmark(
                     results=result_dict,
                     meta=metadata if metadata else {},
                     code=code_snippet,
+                    output_dir=output_dir,
                 )
         else:
             error_message = exec_result.get("stderr") or "An unknown error occurred."
@@ -155,17 +177,18 @@ def run_agent_session(
     llm_client: object,
     sandbox_manager: SandboxManager,
     history: List[Dict[str, str]],
-    compress_memory: bool = False,
     is_auto: bool,
+    compress_memory: bool = False,
     max_turns: int = 1,
     model_name: str = "gpt-4.1",
     benchmark_modules: Optional[List[Path]] = None,
+    output_dir: Optional[Path] = None, # <-- ADDED output_dir parameter
 ):
     """
-    Main driver for both interactive and automated agent execution sessions.
+    Main driver for agent execution sessions, passing output_dir for benchmark saving.
     """
     from rich.prompt import Prompt
-    _init_paths()
+    _init_paths(output_dir)
 
     memory_manager: Optional[MemoryManager] = None
     if compress_memory:
@@ -217,7 +240,8 @@ def run_agent_session(
         query_from_re = detect_rag(msg)
         if query_from_re and current_agent.is_rag_enabled:
             console.print(f"[yellow]🔍 Triggering RAG query: {query_from_re}[/yellow]")
-            retrieved_docs = RAG.query(query_from_re)
+            rag_client = get_rag_client(console)
+            retrieved_docs = rag_client.query(query_from_re)
             if retrieved_docs:
                 console.print(f"[green] RAG query successful. [/green]")
                 feedback = retrieved_docs
@@ -253,7 +277,7 @@ def run_agent_session(
             last_code_snippet = code
             console.print("[cyan]Executing code in sandbox…[/cyan]")
             exec_result = sandbox_manager.exec_code(code, timeout=300)
-            feedback = format_execute_response(exec_result, _OUTPUTS_DIR)
+            feedback = format_execute_response(exec_result, output_dir if output_dir else _DEFAULT_RUNS_DIR)
             if memory_manager:
                 memory_manager.add_message("system", feedback)
                 if exec_result.get("status") == "ok":
@@ -282,7 +306,8 @@ def run_agent_session(
                 if function_name:
                     function_name = function_name[0]
                     console.print(f"[yellow]🔍 Incorrect function signature detected: {function_name}, function database search...[/yellow]")
-                    retrieved_docs = RAG.retrieve_function(function_name)
+                    rag_client = get_rag_client(console)
+                    retrieved_docs = rag_client.retrieve_function(function_name)
                     if retrieved_docs:
                         console.print(f"[green] Query successful - Function signature found. [/green]")
                         feedback += f"\n {function_name} produced an error. The correct function signature for {function_name} is:\n{retrieved_docs}"
@@ -296,7 +321,7 @@ def run_agent_session(
             if benchmark_modules:
                 result_str = run_benchmark(
                     console, sandbox_manager, benchmark_modules[0],
-                    is_auto=True, metadata={"name": "auto"}, agent_name=current_agent.name, code_snippet=last_code_snippet
+                    is_auto=True, metadata={"name": "auto"}, agent_name=current_agent.name, code_snippet=last_code_snippet, output_dir=output_dir
                 )
                 if memory_manager:
                     memory_manager.add_message("system", result_str)
@@ -318,7 +343,7 @@ def run_agent_session(
                 if user_input.lower() == "benchmark":
                     if benchmark_modules:
                         for bm_module in benchmark_modules:
-                            run_benchmark(console, sandbox_manager, bm_module, is_auto=False)
+                            run_benchmark(console, sandbox_manager, bm_module, is_auto=False, output_dir=output_dir)
                         continue
                     else:
                         console.print("[yellow]No benchmark modules were specified at startup.[/yellow]")

--- a/caribou/src/caribou/rag/RetrievalAugmentedGeneration.py
+++ b/caribou/src/caribou/rag/RetrievalAugmentedGeneration.py
@@ -3,21 +3,26 @@ import sys
 from pathlib import Path
 from typing import List, Dict, Optional
 from contextlib import redirect_stdout, redirect_stderr
+import io # Import io for suppressing output
 
 import os
 os.environ['TF_CPP_MIN_LOG_LEVEL'] = '3'
 os.environ['TF_ENABLE_ONEDNN_OPTS'] = '0'
+
 # ── Dependencies ─────────────────────────────────────────────
-try: 
-    import re 
+try:
+    import re
     from sentence_transformers import SentenceTransformer
     from rich.console import Console
     import matplotlib.pyplot as plt
     import numpy as np
-    
+    # Import specific exceptions that might occur during download
+    import requests.exceptions
+    import urllib3.exceptions
+
 except ImportError as e:
     print(f"Missing dependency: {e}", file=sys.stderr)
-    sys.exit(1) 
+    sys.exit(1)
 
 # ── Paths and Constants ─────────────────────────────────────────────
 console = Console()
@@ -28,61 +33,158 @@ FUNCTIONS_FILE = RAG_DIR / "functions.jsonl"
 MIN_SIMILARITY = 0.7
 
 class RetrievalAugmentedGeneration():
-    model = SentenceTransformer("Qwen/Qwen3-Embedding-0.6B")
 
     def __init__(self):
         self.embeddings = self.load_embeddings()
         self.functions = self.load_functions()
+        self.model = None # Initialize model as None
+        self.model_loaded = False # Flag to track model loading status
         self.queries = []
+        self._load_model() # Attempt to load the model during initialization
+
+    def _load_model(self):
+        """Attempts to load the SentenceTransformer model."""
+        model_name = "Qwen/Qwen3-Embedding-0.6B"
+        try:
+            # Suppress potential stdout/stderr during model download/loading
+            # (e.g., download progress bars, warnings)
+            # Use io.StringIO to capture and discard output
+            stdout_trap = io.StringIO()
+            stderr_trap = io.StringIO()
+            with redirect_stdout(stdout_trap), redirect_stderr(stderr_trap):
+                self.model = SentenceTransformer(model_name)
+            self.model_loaded = True
+            console.log(f"[green]Successfully loaded SentenceTransformer model: {model_name}")
+        # Catch specific network-related exceptions
+        except (requests.exceptions.ConnectionError,
+                requests.exceptions.Timeout,
+                urllib3.exceptions.MaxRetryError,
+                urllib3.exceptions.NewConnectionError,
+                OSError, # Can sometimes manifest as OSError (e.g., Name or service not known)
+                ValueError # Can occur if model identifier is invalid or files missing
+               ) as e:
+            console.log(f"[yellow]⚠️ Failed to load SentenceTransformer model '{model_name}'. "
+                        f"Network/Connection issue: {type(e).__name__}. RAG queries will be disabled.")
+            console.log(f"[yellow]Error details: {e}")
+            self.model = None
+            self.model_loaded = False
+        except Exception as e: # Catch any other unexpected errors during loading
+             console.log(f"[red]❌ An unexpected error occurred loading SentenceTransformer model '{model_name}': {e}")
+             self.model = None
+             self.model_loaded = False
+
 
     def load_embeddings(self) -> List[np.ndarray]:
+        if not EMBEDDING_FILE.exists():
+            console.log(f"[yellow]Embeddings file not found at {EMBEDDING_FILE}. No embeddings loaded.")
+            return []
         try:
             with open(EMBEDDING_FILE, "r", encoding="utf-8") as f:
-                return [np.array(json.loads(line)) for line in f if line.strip()]
-        except FileNotFoundError:
-            console.log("[red]Embeddings file not found.")
-            return []
+                embeddings = [np.array(json.loads(line)) for line in f if line.strip()]
+                console.log(f"[green]Loaded {len(embeddings)} embeddings from {EMBEDDING_FILE}")
+                return embeddings
         except json.JSONDecodeError:
-            console.log("[red]Embeddings file is not valid JSONL.")
+            console.log(f"[red]Embeddings file {EMBEDDING_FILE} is not valid JSONL.")
             return []
-    
+        except Exception as e:
+            console.log(f"[red]Error loading embeddings from {EMBEDDING_FILE}: {e}")
+            return []
+
     def load_functions(self) -> List[Dict[str, str]]:
+        if not FUNCTIONS_FILE.exists():
+            console.log(f"[yellow]Functions file not found at {FUNCTIONS_FILE}. No functions loaded.")
+            return []
         try:
             with open(FUNCTIONS_FILE, "r", encoding="utf-8") as f:
-                return [json.loads(line) for line in f if line.strip()]
-        except FileNotFoundError:
-            console.log("[red]Functions file not found.")
-            return []
+                functions = [json.loads(line) for line in f if line.strip()]
+                console.log(f"[green]Loaded {len(functions)} functions from {FUNCTIONS_FILE}")
+                return functions
         except json.JSONDecodeError:
-            console.log("[red]Functions file is not valid JSONL.")
+            console.log(f"[red]Functions file {FUNCTIONS_FILE} is not valid JSONL.")
+            return []
+        except Exception as e:
+            console.log(f"[red]Error loading functions from {FUNCTIONS_FILE}: {e}")
             return []
 
     @staticmethod
     def cosine_similarity(A: np.ndarray, B: List[np.ndarray]) -> List[float]:
-        sims = [np.dot(A, emb) / (np.linalg.norm(A) * np.linalg.norm(emb)) for emb in B]
+        # Ensure B is not empty and contains valid arrays
+        if not B or not all(isinstance(emb, np.ndarray) and emb.size > 0 for emb in B):
+            return []
+        # Ensure A is valid
+        if not isinstance(A, np.ndarray) or A.size == 0:
+            return [0.0] * len(B)
+
+        sims = []
+        norm_A = np.linalg.norm(A)
+        if norm_A == 0: # Avoid division by zero if A is a zero vector
+             return [0.0] * len(B)
+
+        for emb in B:
+            norm_emb = np.linalg.norm(emb)
+            if norm_emb == 0: # Avoid division by zero if emb is a zero vector
+                sims.append(0.0)
+            else:
+                sims.append(np.dot(A, emb) / (norm_A * norm_emb))
         return sims
 
     def retrieve_function(self, name:str) -> Optional[str]:
+        # Check if functions were loaded
+        if not hasattr(self, 'functions') or not self.functions:
+             console.log("[yellow]No functions loaded to retrieve from.")
+             return None
         for function in self.functions:
-            if name in function["signature"]:
+            if "signature" in function and name in function["signature"]:
                 return function["signature"]
         return None
 
-    def query(self, text_query: str) -> Optional[np.ndarray]:
+    def query(self, text_query: str) -> Optional[str]: # Return type changed for clarity
+        """
+        Encodes a text query and finds the most similar function signature.
+
+        Args:
+            text_query: The natural language query string.
+
+        Returns:
+            The signature of the most similar function if found above the threshold,
+            otherwise None. Returns None immediately if the model failed to load.
+        """
         self.queries.append(text_query)
+
+        # === Mocking Check ===
+        if not self.model_loaded or self.model is None:
+            # console.log("[yellow]Model not loaded. RAG query is mocked, returning None.")
+            return None # Return None as requested for failed download
+
+        # === Standard Query Logic ===
         if not self.embeddings:
-            console.log("[yellow]No embeddings to compare.")
+            # console.log("[yellow]No embeddings loaded to compare against.")
             return None
-        query_embedding = self.model.encode([text_query])[0]
-        sims = self.cosine_similarity(query_embedding, self.embeddings)
-        idx = np.argmax(sims)
-        if sims[idx] < MIN_SIMILARITY:
+        if not self.functions:
+            # console.log("[yellow]No functions loaded to return.")
             return None
-        return self.functions[idx]["signature"]
 
- # ──────Implementation──────────────────────────────────────────────────────────
+        try:
+            query_embedding = self.model.encode([text_query])[0]
+            sims = self.cosine_similarity(query_embedding, self.embeddings)
 
-if __name__ == "__main__":
-    rag = RetrievalAugmentedGeneration()
-    print(rag.query("Find a function to download model"))
-    print(rag.query("AttributeError: module 'celltypist.models' has no attribute 'download_model'"))
+            if not sims: # Handle case where similarity calculation failed or returned empty
+                # console.log("[yellow]Similarity calculation yielded no results.")
+                return None
+
+            idx = np.argmax(sims)
+
+            # Ensure index is valid for the functions list
+            if idx >= len(self.functions):
+                 console.log(f"[red]Calculated index {idx} is out of bounds for functions list (length {len(self.functions)}).")
+                 return None
+
+            if sims[idx] >= MIN_SIMILARITY:
+                # console.log(f"Query '{text_query[:50]}...' matched function {idx} with similarity {sims[idx]:.4f}")
+                return self.functions[idx].get("signature") # Use .get for safety
+            else:
+                # console.log(f"Query '{text_query[:50]}...' - No function found above similarity threshold ({sims[idx]:.4f} < {MIN_SIMILARITY})")
+                return None
+        except Exception as e:
+            console.log(f"[red]Error during RAG query processing: {e}")
+            return None


### PR DESCRIPTION
This pull request introduces a new `--output-dir` option to the `caribou run` CLI and refactors the session execution logic to support fully automated, non-interactive runs with explicit output directory management. The changes enable seamless integration with automated benchmarking scripts (such as SLURM jobs), allowing all outputs and logs to be saved without user prompts. The updates also improve the handling of output files and chat logs, and streamline the CLI's option handling.

The most important changes are:

### Automated Output Directory Support

* Added an `--output-dir` (`-o`) option to the `caribou run` CLI and subcommands, allowing users to specify a directory where all outputs (files and chat logs) are saved automatically, bypassing interactive prompts. This is essential for batch or automated runs. [[1]](diffhunk://#diff-38b3b29dea0e32cb1cc3f2118d70d126903c65ca8697257b3cbe590908e646e2L62-R63) [[2]](diffhunk://#diff-38b3b29dea0e32cb1cc3f2118d70d126903c65ca8697257b3cbe590908e646e2R272) [[3]](diffhunk://#diff-38b3b29dea0e32cb1cc3f2118d70d126903c65ca8697257b3cbe590908e646e2L275-R288) [[4]](diffhunk://#diff-38b3b29dea0e32cb1cc3f2118d70d126903c65ca8697257b3cbe590908e646e2L352-R361) [[5]](diffhunk://#diff-38b3b29dea0e32cb1cc3f2118d70d126903c65ca8697257b3cbe590908e646e2L371-L447) [[6]](diffhunk://#diff-38b3b29dea0e32cb1cc3f2118d70d126903c65ca8697257b3cbe590908e646e2R488)

* Refactored the session setup logic in `_setup_and_run_session` to use the provided output directory if set, otherwise defaulting to a timestamped temporary directory. Output directory existence is ensured, and all generated files and logs are saved there in auto mode. [[1]](diffhunk://#diff-38b3b29dea0e32cb1cc3f2118d70d126903c65ca8697257b3cbe590908e646e2L139-L152) [[2]](diffhunk://#diff-38b3b29dea0e32cb1cc3f2118d70d126903c65ca8697257b3cbe590908e646e2R187-R247)

### Non-Interactive and Interactive Mode Handling

* Modified file output and chat log saving logic to automatically save all outputs in non-interactive (auto) mode, and to prompt the user only in interactive mode. This includes defaulting to notebook format for chat logs in auto mode and skipping prompts for reference datasets and Ollama host when `--output-dir` is set. [[1]](diffhunk://#diff-38b3b29dea0e32cb1cc3f2118d70d126903c65ca8697257b3cbe590908e646e2L299-R307) [[2]](diffhunk://#diff-38b3b29dea0e32cb1cc3f2118d70d126903c65ca8697257b3cbe590908e646e2R187-R247) [[3]](diffhunk://#diff-38b3b29dea0e32cb1cc3f2118d70d126903c65ca8697257b3cbe590908e646e2L352-R361)

### CLI and Codebase Improvements

* Improved option merging and extraction logic to support the new `output_dir` parameter, ensuring consistent handling of CLI options across commands and subcommands.

* Cleaned up and clarified comments, docstrings, and logic for merging CLI options and initializing context, making the code easier to maintain and extend. [[1]](diffhunk://#diff-38b3b29dea0e32cb1cc3f2118d70d126903c65ca8697257b3cbe590908e646e2L371-L447) [[2]](diffhunk://#diff-38b3b29dea0e32cb1cc3f2118d70d126903c65ca8697257b3cbe590908e646e2L474-R471)

### Benchmarking Script Addition

* Added a new SLURM-compatible benchmarking script, `auto_run_template.sh`, which demonstrates how to run multiple automated jobs with the new `--output-dir` option and other parameters, further supporting batch processing workflows.